### PR TITLE
Enable custom clone function to call allocator.Clone(old)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,22 +232,18 @@ fmt.Println(w.Foo) // 123
 
 ## Performance
 
-Here is the performance data running on my MacBook Pro.
+Here is the performance data running on my dev machine.
 
 ```text
-MacBook Pro (15-inch, 2019)
-Processor: 2.6 GHz Intel Core i7
-
-go 1.19
+go 1.20.1
 goos: darwin
 goarch: amd64
-pkg: github.com/huandu/go-clone
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-BenchmarkSimpleClone-12          7903873               142.9 ns/op            24 B/op          1 allocs/op
-BenchmarkComplexClone-12          590836                1755 ns/op          1488 B/op         21 allocs/op
-BenchmarkUnwrap-12              14988664               71.46 ns/op             0 B/op          0 allocs/op
-BenchmarkSimpleWrap-12           3823450               304.4 ns/op            72 B/op          2 allocs/op
-BenchmarkComplexWrap-12           867642                1197 ns/op           736 B/op         15 allocs/op
+BenchmarkSimpleClone-12       7164530        156.7 ns/op       24 B/op        1 allocs/op
+BenchmarkComplexClone-12       628056         1871 ns/op     1488 B/op       21 allocs/op
+BenchmarkUnwrap-12           15498139        78.02 ns/op        0 B/op        0 allocs/op
+BenchmarkSimpleWrap-12        3882360        309.7 ns/op       72 B/op        2 allocs/op
+BenchmarkComplexWrap-12        949654         1245 ns/op      736 B/op       15 allocs/op
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -166,7 +166,16 @@ I will update the default.
 ### Set custom clone functions
 
 If default clone strategy doesn't work for a struct type, we can call `SetCustomFunc` to register a custom clone function.
-`Clone` and `Slowly` can be used in custom clone functions.
+
+```go
+SetCustomFunc(reflect.TypeOf(MyType{}), func(allocator *Allocator, old, new reflect.Value) {
+    // Customized logic to copy the old to the new.
+    // The old's type is MyType.
+    // The new is a zero value of MyType and new.CanAddr() always returns true.
+})
+```
+
+We can call `allocator.Clone` or `allocator.Slowly` to clone any value in depth. It's allowed to call these clone methods on `old` to clone its fields in depth.
 
 See [SetCustomFunc sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-SetCustomFunc) for more details.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ SetCustomFunc(reflect.TypeOf(MyType{}), func(allocator *Allocator, old, new refl
 })
 ```
 
-We can call `allocator.Clone` or `allocator.Slowly` to clone any value in depth. It's allowed to call these clone methods on `old` to clone its fields in depth.
+We can use `allocator` to clone any value or allocate new memory.
+It's allowed to call `allocator.Clone` or `allocator.CloneSlowly` on `old` to clone its struct fields in depth without worrying about dead loop.
 
 See [SetCustomFunc sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-SetCustomFunc) for more details.
 

--- a/allocator.go
+++ b/allocator.go
@@ -102,6 +102,10 @@ func (a *Allocator) MakeChan(t reflect.Type, buffer int) reflect.Value {
 
 // Clone recursively deep clone val to a new value with memory allocated from a.
 func (a *Allocator) Clone(val reflect.Value) reflect.Value {
+	return a.clone(val, true)
+}
+
+func (a *Allocator) clone(val reflect.Value, inCustomFunc bool) reflect.Value {
 	if !val.IsValid() {
 		return val
 	}
@@ -109,12 +113,21 @@ func (a *Allocator) Clone(val reflect.Value) reflect.Value {
 	state := &cloneState{
 		allocator: a,
 	}
+
+	if inCustomFunc {
+		state.skipCustomFuncValue = val
+	}
+
 	return state.clone(val)
 }
 
 // CloneSlowly recursively deep clone val to a new value with memory allocated from a.
 // It marks all cloned values internally, thus it can clone v with cycle pointer.
 func (a *Allocator) CloneSlowly(val reflect.Value) reflect.Value {
+	return a.cloneSlowly(val, true)
+}
+
+func (a *Allocator) cloneSlowly(val reflect.Value, inCustomFunc bool) reflect.Value {
 	if !val.IsValid() {
 		return val
 	}
@@ -124,6 +137,11 @@ func (a *Allocator) CloneSlowly(val reflect.Value) reflect.Value {
 		visited:   visitMap{},
 		invalid:   invalidPointers{},
 	}
+
+	if inCustomFunc {
+		state.skipCustomFuncValue = val
+	}
+
 	cloned := state.clone(val)
 	state.fix(cloned)
 	return cloned


### PR DESCRIPTION
In a custom clone function, we may need to do a clone on the old value first, then update some fields of cloned value manually. To enable us to work like this, `allocator.Clone` and `allocator.CloneSlowly` can temporarily disable custom clone function on the old value to avoid dead loop.

See example `ExampleSetCustomFunc_partiallyClone` for more details.