### PR TITLE
Let Allocator hold all customization data

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,12 @@ func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) *Allocator
 - The second parameter `methods` is a pointer to a struct which contains all methods to allocate memory. It can be `nil` if we don't need to customize memory allocation.
 - The `Allocator` struct is allocated from the `methods.New` or the `methods.Parent` allocator or from heap.
 
-The `Parent` in `AllocatorMethods` is used to indicate the parent of the new allocator. With this feature, we can orgnize allocators into a tree structure and build a leveled memory pool. When allocating memory, the allocator will try to allocate memory from its own pool first. If the pool is full, it will try to allocate memory from its parent's pool. If the parent's pool is full, it will try to allocate memory from its parent's parent's pool. And so on. If the root allocator's pool is full, it will allocate memory from heap.
+The `Parent` in `AllocatorMethods` is used to indicate the parent of the new allocator. With this feature, we can orgnize allocators into a tree structure. All customizations, including custom clone functions, scalar types and opaque pointers, etc, are inherited from parent allocators.
 
-For convenience, we can create dedicated allocators for heap or arena by calling `FromHeap()` or `FromArena(a *arena.Arena)`.
+There are some APIs designed for convenience.
+
+- We can create dedicated allocators for heap or arena by calling `FromHeap()` or `FromArena(a *arena.Arena)`.
+- We can call `MakeCloner(allocator)` to create a helper struct with `Clone` and `CloneSlowly` methods in which the type of in and out parameters is `interface{}`.
 
 ### Mark struct type as scalar
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,19 @@ The `Allocator` is designed to allocate memory when cloning. It's also used to h
 
 We can control how to allocate memory by creating a new `Allocator` by `NewAllocator`. It enables us to take full control over memory allocation when cloning. See [Allocator sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-Allocator) to understand how to customize an allocator.
 
-For convenience, we can create dedicated allocators for heap or arena by calling `FromHeap()` or `FromArena(a arena.Arena)`.
+Let's take a closer look at the `NewAllocator` function.
+
+```go
+func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) *Allocator
+```
+
+- The first parameter `pool` is a pointer to a memory pool. It's used to allocate memory for cloning. It can be `nil` if we don't need a memory pool.
+- The second parameter `methods` is a pointer to a struct which contains all methods to allocate memory. It can be `nil` if we don't need to customize memory allocation.
+- The `Allocator` struct is allocated from the `methods.New` or the `methods.Parent` allocator or from heap.
+
+The `Parent` in `AllocatorMethods` is used to indicate the parent of the new allocator. With this feature, we can orgnize allocators into a tree structure and build a leveled memory pool. When allocating memory, the allocator will try to allocate memory from its own pool first. If the pool is full, it will try to allocate memory from its parent's pool. If the parent's pool is full, it will try to allocate memory from its parent's parent's pool. And so on. If the root allocator's pool is full, it will allocate memory from heap.
+
+For convenience, we can create dedicated allocators for heap or arena by calling `FromHeap()` or `FromArena(a *arena.Arena)`.
 
 ### Mark struct type as scalar
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Due to limitations in arena API, memory of the internal data structure of `map` 
 
 **Warning**: Per [discussion in the arena proposal](https://github.com/golang/go/issues/51317), the arena package may be changed incompatibly or removed in future. All arena related APIs in this package will be changed accordingly.
 
-### Customized allocator
+### Memory allocations and the `Allocator`
 
-We can control how to allocate memory by creating an `Allocator`. It enables us to take full control over memory allocation when cloning. See [Allocator sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-Allocator) to understand how to use `sync.Pool` in allocator.
+The `Allocator` is designed to allocate memory when cloning. It's also used to hold all customizations, e.g. custom clone functions, scalar types and opaque pointers, etc. There is a default allocator which allocates memory from heap. Almost all public APIs in this package use this default allocator to do their job.
+
+We can control how to allocate memory by creating a new `Allocator` by `NewAllocator`. It enables us to take full control over memory allocation when cloning. See [Allocator sample code](https://pkg.go.dev/github.com/huandu/go-clone#example-Allocator) to understand how to customize an allocator.
 
 For convenience, we can create dedicated allocators for heap or arena by calling `FromHeap()` or `FromArena(a arena.Arena)`.
-
-There is a default heap allocator which holds all custom clone functions, scalar types and opaque types. Almost all public APIs in this package use this default allocator to do their job.
 
 ### Mark struct type as scalar
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ We can control how to allocate memory by creating an `Allocator`. It enables us 
 
 For convenience, we can create dedicated allocators for heap or arena by calling `FromHeap()` or `FromArena(a arena.Arena)`.
 
+There is a default heap allocator which holds all custom clone functions, scalar types and opaque types. Almost all public APIs in this package use this default allocator to do their job.
+
 ### Mark struct type as scalar
 
 Some struct types can be considered as scalar.

--- a/allocator.go
+++ b/allocator.go
@@ -12,8 +12,8 @@ import (
 
 var typeOfAllocator = reflect.TypeOf(Allocator{})
 
-// The heapAllocator allocates memory from heap.
-var heapAllocator = FromHeap()
+// defaultAllocator is the default allocator and allocates memory from heap.
+var defaultAllocator = FromHeap()
 
 // Allocator is a utility type for memory allocation.
 type Allocator struct {

--- a/allocator.go
+++ b/allocator.go
@@ -6,10 +6,14 @@ package clone
 import (
 	"reflect"
 	"runtime"
+	"sync"
 	"unsafe"
 )
 
 var typeOfAllocator = reflect.TypeOf(Allocator{})
+
+// The heapAllocator allocates memory from heap.
+var heapAllocator = FromHeap()
 
 // Allocator is a utility type for memory allocation.
 type Allocator struct {
@@ -18,6 +22,11 @@ type Allocator struct {
 	makeSlice func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value
 	makeMap   func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value
 	makeChan  func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value
+	isScalar  func(t reflect.Kind) bool
+
+	cachedStructTypes     sync.Map
+	cachedPointerTypes    sync.Map
+	cachedCustomFuncTypes sync.Map
 }
 
 // AllocatorMethods defines all methods required by allocator.
@@ -27,24 +36,42 @@ type AllocatorMethods struct {
 	MakeSlice func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value
 	MakeMap   func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value
 	MakeChan  func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value
+	IsScalar  func(t reflect.Kind) bool
 }
 
-// FromHeap returns an allocator which allocate memory from heap.
+// FromHeap creates an allocator which allocate memory from heap.
 func FromHeap() *Allocator {
-	return heapAllocator
+	return NewAllocator(nil, nil)
 }
 
 // NewAllocator creates an allocator which allocate memory from the pool.
+// Both pool and methods are optional.
 //
 // If methods.New is not nil, the allocator itself is created by calling methods.New.
+//
+// The pool is a pointer to the memory pool which is opaque to the allocator.
+// It's methods's responsibility to allocate memory from the pool properly.
 func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) (allocator *Allocator) {
-	if methods.New == nil {
+	if methods == nil {
+		allocator = &Allocator{
+			pool: pool,
+
+			cachedStructTypes:     sync.Map{},
+			cachedPointerTypes:    sync.Map{},
+			cachedCustomFuncTypes: sync.Map{},
+		}
+	} else if methods.New == nil {
 		allocator = &Allocator{
 			pool:      pool,
 			new:       methods.New,
 			makeSlice: methods.MakeSlice,
 			makeMap:   methods.MakeMap,
 			makeChan:  methods.MakeChan,
+			isScalar:  methods.IsScalar,
+
+			cachedStructTypes:     sync.Map{},
+			cachedPointerTypes:    sync.Map{},
+			cachedCustomFuncTypes: sync.Map{},
 		}
 	} else {
 		// Allocate the allocator from the pool.
@@ -58,6 +85,11 @@ func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) (allocator *Al
 			makeSlice: methods.MakeSlice,
 			makeMap:   methods.MakeMap,
 			makeChan:  methods.MakeChan,
+			isScalar:  methods.IsScalar,
+
+			cachedStructTypes:     sync.Map{},
+			cachedPointerTypes:    sync.Map{},
+			cachedCustomFuncTypes: sync.Map{},
 		}
 	}
 
@@ -75,6 +107,10 @@ func NewAllocator(pool unsafe.Pointer, methods *AllocatorMethods) (allocator *Al
 
 	if allocator.makeChan == nil {
 		allocator.makeChan = heapMakeChan
+	}
+
+	if allocator.isScalar == nil {
+		allocator.isScalar = IsScalar
 	}
 
 	return allocator
@@ -147,12 +183,128 @@ func (a *Allocator) cloneSlowly(val reflect.Value, inCustomFunc bool) reflect.Va
 	return cloned
 }
 
-// The heapAllocator allocates memory from heap.
-var heapAllocator = &Allocator{
-	new:       heapNew,
-	makeSlice: heapMakeSlice,
-	makeMap:   heapMakeMap,
-	makeChan:  heapMakeChan,
+func (a *Allocator) loadStructType(t reflect.Type) (st structType) {
+	if v, ok := a.cachedStructTypes.Load(t); ok {
+		st = v.(structType)
+		return
+	}
+
+	num := t.NumField()
+	pointerFields := make([]structFieldType, 0, num)
+
+	for i := 0; i < num; i++ {
+		field := t.Field(i)
+		ft := field.Type
+		k := ft.Kind()
+
+		if a.isScalar(k) {
+			continue
+		}
+
+		switch k {
+		case reflect.Array:
+			if ft.Len() == 0 {
+				continue
+			}
+
+			elem := ft.Elem()
+
+			if a.isScalar(elem.Kind()) {
+				continue
+			}
+
+			if elem.Kind() == reflect.Struct {
+				if fst := a.loadStructType(elem); fst.CanShadowCopy() {
+					continue
+				}
+			}
+		case reflect.Struct:
+			if fst := a.loadStructType(ft); fst.CanShadowCopy() {
+				continue
+			}
+		}
+
+		pointerFields = append(pointerFields, structFieldType{
+			Offset: field.Offset,
+			Index:  i,
+		})
+	}
+
+	if len(pointerFields) == 0 {
+		pointerFields = nil // Release memory ASAP.
+	}
+
+	st = structType{
+		PointerFields: pointerFields,
+	}
+
+	if fn, ok := a.cachedCustomFuncTypes.Load(t); ok {
+		st.fn = fn.(Func)
+	}
+
+	a.cachedStructTypes.LoadOrStore(t, st)
+	return
+}
+
+func (a *Allocator) isOpaquePointer(t reflect.Type) (ok bool) {
+	_, ok = a.cachedPointerTypes.Load(t)
+	return
+}
+
+// MarkAsScalar marks t as a scalar type so that all clone methods will copy t by value.
+// If t is not struct or pointer to struct, MarkAsScalar ignores t.
+//
+// In the most cases, it's not necessary to call it explicitly.
+// If a struct type contains scalar type fields only, the struct will be marked as scalar automatically.
+//
+// Here is a list of types marked as scalar by default:
+//   - time.Time
+//   - reflect.Value
+func (a *Allocator) MarkAsScalar(t reflect.Type) {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	a.cachedStructTypes.Store(t, zeroStructType)
+}
+
+// MarkAsOpaquePointer marks t as an opaque pointer so that all clone methods will copy t by value.
+// If t is not a pointer, MarkAsOpaquePointer ignores t.
+//
+// Here is a list of types marked as opaque pointers by default:
+//   - `elliptic.Curve`, which is `*elliptic.CurveParam` or `elliptic.p256Curve`;
+//   - `reflect.Type`, which is `*reflect.rtype` defined in `runtime`.
+func (a *Allocator) MarkAsOpaquePointer(t reflect.Type) {
+	if t.Kind() != reflect.Ptr {
+		return
+	}
+
+	a.cachedPointerTypes.Store(t, struct{}{})
+}
+
+// SetCustomFunc sets a custom clone function for type t.
+// If t is not struct or pointer to struct, SetCustomFunc ignores t.
+//
+// If fn is nil, remove the custom clone function for type t.
+func (a *Allocator) SetCustomFunc(t reflect.Type, fn Func) {
+	if fn == nil {
+		a.cachedCustomFuncTypes.Delete(t)
+		return
+	}
+
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	a.cachedCustomFuncTypes.Store(t, fn)
 }
 
 func heapNew(pool unsafe.Pointer, t reflect.Type) reflect.Value {

--- a/allocator_sample_test.go
+++ b/allocator_sample_test.go
@@ -14,6 +14,31 @@ import (
 )
 
 func ExampleAllocator() {
+	// We can create a new allocator to hold customized config without poluting the default allocator.
+	// Calling FromHeap() is a convenient way to create a new allocator which allocates memory from heap.
+	allocator := FromHeap()
+
+	// Mark T as scalar only in the allocator.
+	type T struct {
+		Value *int
+	}
+	allocator.MarkAsScalar(reflect.TypeOf(new(T)))
+
+	t := &T{
+		Value: new(int),
+	}
+	cloned1 := allocator.Clone(reflect.ValueOf(t)).Interface().(*T)
+	cloned2 := Clone(t).(*T)
+
+	fmt.Println(t.Value == cloned1.Value)
+	fmt.Println(t.Value == cloned2.Value)
+
+	// Output:
+	// true
+	// false
+}
+
+func ExampleAllocator_syncPool() {
 	type Foo struct {
 		Bar int
 	}

--- a/allocator_sample_test.go
+++ b/allocator_sample_test.go
@@ -99,11 +99,12 @@ func ExampleAllocator_deepCloneString() {
 			return t != reflect.String && IsScalar(t)
 		},
 	})
+	cloner := MakeCloner(allocator)
 
 	data := []byte("bytes")
-	s1 := *(*string)(unsafe.Pointer(&data))             // Unsafe conversion from []byte to string.
-	s2 := Clone(s1).(string)                            // s2 shares the same underlying bytes with s1.
-	s3 := allocator.Clone(reflect.ValueOf(s1)).String() // s3 has its own underlying bytes.
+	s1 := *(*string)(unsafe.Pointer(&data)) // Unsafe conversion from []byte to string.
+	s2 := Clone(s1).(string)                // s2 shares the same underlying bytes with s1.
+	s3 := cloner.Clone(s1).(string)         // s3 has its own underlying bytes.
 
 	copy(data, "magic") // Change the underlying bytes.
 	fmt.Println(s1)

--- a/allocatormethods.go
+++ b/allocatormethods.go
@@ -1,0 +1,115 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// AllocatorMethods defines all methods required by allocator.
+// If any of these methods is nil, allocator will use default method which allocates memory from heap.
+type AllocatorMethods struct {
+	// Parent is the allocator which handles all unhandled methods.
+	// If it's nil, it will be the default allocator.
+	Parent *Allocator
+
+	New       func(pool unsafe.Pointer, t reflect.Type) reflect.Value
+	MakeSlice func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value
+	MakeMap   func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value
+	MakeChan  func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value
+	IsScalar  func(k reflect.Kind) bool
+}
+
+func (am *AllocatorMethods) parent() *Allocator {
+	if am != nil && am.Parent != nil {
+		return am.Parent
+	}
+
+	return nil
+}
+
+func (am *AllocatorMethods) new(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type) reflect.Value {
+	if am != nil && am.New != nil {
+		return am.New
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.new
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type) reflect.Value {
+				return parent.New(t)
+			}
+		}
+	}
+
+	return defaultAllocator.new
+}
+
+func (am *AllocatorMethods) makeSlice(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value {
+	if am != nil && am.MakeSlice != nil {
+		return am.MakeSlice
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.makeSlice
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value {
+				return parent.MakeSlice(t, len, cap)
+			}
+		}
+	}
+
+	return defaultAllocator.makeSlice
+}
+
+func (am *AllocatorMethods) makeMap(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value {
+	if am != nil && am.MakeMap != nil {
+		return am.MakeMap
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.makeMap
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type, n int) reflect.Value {
+				return parent.MakeMap(t, n)
+			}
+		}
+	}
+
+	return defaultAllocator.makeMap
+}
+
+func (am *AllocatorMethods) makeChan(parent *Allocator, pool unsafe.Pointer) func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value {
+	if am != nil && am.MakeChan != nil {
+		return am.MakeChan
+	}
+
+	if parent != nil {
+		if parent.pool == pool {
+			return parent.makeChan
+		} else {
+			return func(pool unsafe.Pointer, t reflect.Type, buffer int) reflect.Value {
+				return parent.MakeChan(t, buffer)
+			}
+		}
+	}
+
+	return defaultAllocator.makeChan
+}
+
+func (am *AllocatorMethods) isScalar(parent *Allocator) func(t reflect.Kind) bool {
+	if am != nil && am.IsScalar != nil {
+		return am.IsScalar
+	}
+
+	if parent != nil {
+		return parent.isScalar
+	}
+
+	return defaultAllocator.isScalar
+}

--- a/allocatormethods_test.go
+++ b/allocatormethods_test.go
@@ -1,0 +1,121 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/huandu/go-assert"
+)
+
+func TestAllocatorMethodsParent(t *testing.T) {
+	a := assert.New(t)
+	parent := NewAllocator(nil, &AllocatorMethods{
+		IsScalar: func(k reflect.Kind) bool {
+			return k == reflect.Int
+		},
+	})
+	allocator := NewAllocator(nil, &AllocatorMethods{
+		Parent: parent,
+	})
+
+	a.Assert(parent.parent == defaultAllocator)
+	a.Assert(allocator.parent == parent)
+
+	// Set up customizations in parent.
+	type T1 struct {
+		Data []byte
+	}
+	type T2 struct {
+		Data []byte
+	}
+	type T3 struct {
+		Data []byte
+	}
+	typeOfT1 := reflect.TypeOf(new(T1))
+	typeOfT2 := reflect.TypeOf(new(T2))
+	typeOfT3 := reflect.TypeOf(new(T3))
+	customFuncCalled := 0
+	parent.MarkAsScalar(typeOfT1)
+	parent.MarkAsOpaquePointer(typeOfT2)
+	parent.SetCustomFunc(typeOfT3, func(allocator *Allocator, old, new reflect.Value) {
+		customFuncCalled++
+	})
+
+	// All customizations should be inherited from parent.
+	st1 := allocator.loadStructType(typeOfT1.Elem())
+	st2 := allocator.loadStructType(typeOfT2.Elem())
+	st3 := allocator.loadStructType(typeOfT3.Elem())
+	a.Equal(len(st1.PointerFields), 0)
+	a.Assert(st1.fn == nil)
+	a.Equal(len(st3.PointerFields), 1)
+	a.Assert(st2.fn == nil)
+	a.Equal(len(st3.PointerFields), 1)
+	a.Assert(st3.fn != nil)
+	a.Assert(!allocator.isOpaquePointer(typeOfT1))
+	a.Assert(allocator.isOpaquePointer(typeOfT2))
+	a.Assert(!allocator.isOpaquePointer(typeOfT3))
+	a.Assert(allocator.isScalar(reflect.Int))
+	a.Assert(!allocator.isScalar(reflect.Uint))
+}
+
+func TestAllocatorMethodsPool(t *testing.T) {
+	a := assert.New(t)
+	pool1Called := 0
+	pool1 := &sync.Pool{
+		New: func() interface{} {
+			pool1Called++
+			return nil
+		},
+	}
+	pool2Called := 0
+	pool2 := &sync.Pool{
+		New: func() interface{} {
+			pool2Called++
+			return nil
+		},
+	}
+	parent := NewAllocator(unsafe.Pointer(pool1), &AllocatorMethods{
+		New: func(pool unsafe.Pointer, t reflect.Type) reflect.Value {
+			p := (*sync.Pool)(pool)
+			p.Get()
+			return defaultAllocator.New(t)
+		},
+		MakeSlice: func(pool unsafe.Pointer, t reflect.Type, len, cap int) reflect.Value {
+			p := (*sync.Pool)(pool)
+			p.Get()
+			return defaultAllocator.MakeSlice(t, len, cap)
+		},
+		MakeMap: func(pool unsafe.Pointer, t reflect.Type, size int) reflect.Value {
+			p := (*sync.Pool)(pool)
+			p.Get()
+			return defaultAllocator.MakeMap(t, size)
+		},
+	})
+	allocator := NewAllocator(unsafe.Pointer(pool2), &AllocatorMethods{
+		Parent: parent,
+		MakeChan: func(pool unsafe.Pointer, t reflect.Type, size int) reflect.Value {
+			p := (*sync.Pool)(pool)
+			p.Get()
+			return defaultAllocator.MakeChan(t, size)
+		},
+	})
+
+	// All allocation should be implemented by parent.
+	allocator.New(reflect.TypeOf(1))
+	allocator.MakeSlice(reflect.TypeOf([]int{}), 0, 0)
+	allocator.MakeMap(reflect.TypeOf(map[int]int{}), 0)
+	allocator.MakeChan(reflect.TypeOf(make(chan int)), 0)
+
+	// 1 for new parent allocator itself.
+	// 1 for new allocator itself.
+	// 3 for New, MakeSlice and MakeMap.
+	a.Equal(pool1Called, 5)
+
+	// 1 for MakeChan.
+	a.Equal(pool2Called, 1)
+}

--- a/clone.go
+++ b/clone.go
@@ -14,6 +14,7 @@ import (
 var heapCloneState = &cloneState{
 	allocator: defaultAllocator,
 }
+var cloner = MakeCloner(defaultAllocator)
 
 // Clone recursively deep clone v to a new value in heap.
 // It assumes that there is no pointer cycle in v,
@@ -32,7 +33,7 @@ var heapCloneState = &cloneState{
 // Unlike many other packages, Clone is able to clone unexported fields of any struct.
 // Use this feature wisely.
 func Clone(v interface{}) interface{} {
-	return clone(defaultAllocator, v)
+	return cloner.Clone(v)
 }
 
 func clone(allocator *Allocator, v interface{}) interface{} {
@@ -50,7 +51,7 @@ func clone(allocator *Allocator, v interface{}) interface{} {
 //
 // Slowly works exactly the same as Clone. See Clone doc for more details.
 func Slowly(v interface{}) interface{} {
-	return cloneSlowly(defaultAllocator, v)
+	return cloner.CloneSlowly(v)
 }
 
 func cloneSlowly(allocator *Allocator, v interface{}) interface{} {

--- a/clone.go
+++ b/clone.go
@@ -12,7 +12,7 @@ import (
 )
 
 var heapCloneState = &cloneState{
-	allocator: heapAllocator,
+	allocator: defaultAllocator,
 }
 
 // Clone recursively deep clone v to a new value in heap.
@@ -32,7 +32,7 @@ var heapCloneState = &cloneState{
 // Unlike many other packages, Clone is able to clone unexported fields of any struct.
 // Use this feature wisely.
 func Clone(v interface{}) interface{} {
-	return clone(heapAllocator, v)
+	return clone(defaultAllocator, v)
 }
 
 func clone(allocator *Allocator, v interface{}) interface{} {
@@ -50,7 +50,7 @@ func clone(allocator *Allocator, v interface{}) interface{} {
 //
 // Slowly works exactly the same as Clone. See Clone doc for more details.
 func Slowly(v interface{}) interface{} {
-	return cloneSlowly(heapAllocator, v)
+	return cloneSlowly(defaultAllocator, v)
 }
 
 func cloneSlowly(allocator *Allocator, v interface{}) interface{} {

--- a/clone_test.go
+++ b/clone_test.go
@@ -8,7 +8,7 @@ import "testing"
 func TestCloneAll(t *testing.T) {
 	for name, fn := range testFuncMap {
 		t.Run(name, func(t *testing.T) {
-			fn(t, heapAllocator)
+			fn(t, defaultAllocator)
 		})
 	}
 }

--- a/cloner.go
+++ b/cloner.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+package clone
+
+// Cloner implements clone API with given allocator.
+type Cloner struct {
+	allocator *Allocator
+}
+
+// MakeCloner creates a cloner with given allocator.
+func MakeCloner(allocator *Allocator) Cloner {
+	return Cloner{
+		allocator: allocator,
+	}
+}
+
+// Clone clones v with given allocator.
+func (c Cloner) Clone(v interface{}) interface{} {
+	return clone(c.allocator, v)
+}
+
+// CloneSlowly clones v with given allocator.
+// It can clone v with cycle pointer.
+func (c Cloner) CloneSlowly(v interface{}) interface{} {
+	return cloneSlowly(c.allocator, v)
+}

--- a/structtype.go
+++ b/structtype.go
@@ -23,12 +23,6 @@ type structFieldType struct {
 	Index  int     // The index of the field.
 }
 
-var (
-	cachedStructTypes     sync.Map
-	cachedPointerTypes    sync.Map
-	cachedCustomFuncTypes sync.Map
-)
-
 var zeroStructType = structType{}
 
 func init() {
@@ -107,7 +101,8 @@ func init() {
 	})
 }
 
-// MarkAsScalar marks t as a scalar type so that all clone methods will copy t by value.
+// MarkAsScalar marks t as a scalar type in heap allocator,
+// so that all clone methods will copy t by value.
 // If t is not struct or pointer to struct, MarkAsScalar ignores t.
 //
 // In the most cases, it's not necessary to call it explicitly.
@@ -117,29 +112,18 @@ func init() {
 //   - time.Time
 //   - reflect.Value
 func MarkAsScalar(t reflect.Type) {
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-
-	if t.Kind() != reflect.Struct {
-		return
-	}
-
-	cachedStructTypes.Store(t, zeroStructType)
+	heapAllocator.MarkAsScalar(t)
 }
 
-// MarkAsOpaquePointer marks t as an opaque pointer so that all clone methods will copy t by value.
+// MarkAsOpaquePointer marks t as an opaque pointer in heap allocator,
+// so that all clone methods will copy t by value.
 // If t is not a pointer, MarkAsOpaquePointer ignores t.
 //
 // Here is a list of types marked as opaque pointers by default:
 //   - `elliptic.Curve`, which is `*elliptic.CurveParam` or `elliptic.p256Curve`;
 //   - `reflect.Type`, which is `*reflect.rtype` defined in `runtime`.
 func MarkAsOpaquePointer(t reflect.Type) {
-	if t.Kind() != reflect.Ptr {
-		return
-	}
-
-	cachedPointerTypes.Store(t, struct{}{})
+	heapAllocator.MarkAsOpaquePointer(t)
 }
 
 // Func is a custom func to clone value from old to new.
@@ -153,25 +137,12 @@ type Func func(allocator *Allocator, old, new reflect.Value)
 // It's useful when cloning sync.Mutex as cloned value must be a zero value.
 func emptyCloneFunc(allocator *Allocator, old, new reflect.Value) {}
 
-// SetCustomFunc sets a custom clone function for type t.
+// SetCustomFunc sets a custom clone function for type t in heap allocator.
 // If t is not struct or pointer to struct, SetCustomFunc ignores t.
 //
 // If fn is nil, remove the custom clone function for type t.
 func SetCustomFunc(t reflect.Type, fn Func) {
-	if fn == nil {
-		cachedCustomFuncTypes.Delete(t)
-		return
-	}
-
-	for t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-
-	if t.Kind() != reflect.Struct {
-		return
-	}
-
-	cachedCustomFuncTypes.Store(t, fn)
+	heapAllocator.SetCustomFunc(t, fn)
 }
 
 // Init creates a new value of src.Type() and shadow copies all content from src.
@@ -202,70 +173,19 @@ func (st *structType) CanShadowCopy() bool {
 	return len(st.PointerFields) == 0 && st.fn == nil
 }
 
-func loadStructType(t reflect.Type) (st structType) {
-	if v, ok := cachedStructTypes.Load(t); ok {
-		st = v.(structType)
-		return
-	}
-
-	num := t.NumField()
-	pointerFields := make([]structFieldType, 0, num)
-
-	for i := 0; i < num; i++ {
-		field := t.Field(i)
-		ft := field.Type
-		k := ft.Kind()
-
-		if isScalar(k) {
-			continue
-		}
-
-		switch k {
-		case reflect.Array:
-			if ft.Len() == 0 {
-				continue
-			}
-
-			elem := ft.Elem()
-
-			if isScalar(elem.Kind()) {
-				continue
-			}
-
-			if elem.Kind() == reflect.Struct {
-				if fst := loadStructType(elem); fst.CanShadowCopy() {
-					continue
-				}
-			}
-		case reflect.Struct:
-			if fst := loadStructType(ft); fst.CanShadowCopy() {
-				continue
-			}
-		}
-
-		pointerFields = append(pointerFields, structFieldType{
-			Offset: field.Offset,
-			Index:  i,
-		})
-	}
-
-	if len(pointerFields) == 0 {
-		pointerFields = nil // Release memory ASAP.
-	}
-
-	st = structType{
-		PointerFields: pointerFields,
-	}
-
-	if fn, ok := cachedCustomFuncTypes.Load(t); ok {
-		st.fn = fn.(Func)
-	}
-
-	cachedStructTypes.LoadOrStore(t, st)
-	return
-}
-
-func isScalar(k reflect.Kind) bool {
+// IsScalar returns true if k should be considered as a scalar type.
+//
+// For the sake of performance, string is considered as a scalar type unless arena is enabled.
+// If we need to deep copy string value in some cases, we can create a new allocator with custom isScalar function
+// in which we can return false when k is reflect.String.
+//
+//	// Create a new allocator which treats string as non-scalar type.
+//	allocator := NewAllocator(nil, &AllocatorMethods{
+//		IsScalar: func(k reflect.Kind) bool {
+//			return k != reflect.String && IsScalar(k)
+//		},
+//	})
+func IsScalar(k reflect.Kind) bool {
 	switch k {
 	case reflect.Bool,
 		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
@@ -284,11 +204,6 @@ func isScalar(k reflect.Kind) bool {
 	}
 
 	return false
-}
-
-func isOpaquePointer(t reflect.Type) (ok bool) {
-	_, ok = cachedPointerTypes.Load(t)
-	return
 }
 
 func copyScalarValue(src reflect.Value) reflect.Value {

--- a/structtype.go
+++ b/structtype.go
@@ -112,7 +112,7 @@ func init() {
 //   - time.Time
 //   - reflect.Value
 func MarkAsScalar(t reflect.Type) {
-	heapAllocator.MarkAsScalar(t)
+	defaultAllocator.MarkAsScalar(t)
 }
 
 // MarkAsOpaquePointer marks t as an opaque pointer in heap allocator,
@@ -123,7 +123,7 @@ func MarkAsScalar(t reflect.Type) {
 //   - `elliptic.Curve`, which is `*elliptic.CurveParam` or `elliptic.p256Curve`;
 //   - `reflect.Type`, which is `*reflect.rtype` defined in `runtime`.
 func MarkAsOpaquePointer(t reflect.Type) {
-	heapAllocator.MarkAsOpaquePointer(t)
+	defaultAllocator.MarkAsOpaquePointer(t)
 }
 
 // Func is a custom func to clone value from old to new.
@@ -142,7 +142,7 @@ func emptyCloneFunc(allocator *Allocator, old, new reflect.Value) {}
 //
 // If fn is nil, remove the custom clone function for type t.
 func SetCustomFunc(t reflect.Type, fn Func) {
-	heapAllocator.SetCustomFunc(t, fn)
+	defaultAllocator.SetCustomFunc(t, fn)
 }
 
 // Init creates a new value of src.Type() and shadow copies all content from src.

--- a/structtype_test.go
+++ b/structtype_test.go
@@ -32,7 +32,7 @@ func TestMarkAsScalar(t *testing.T) {
 	a.Use(&oldCnt, &newCnt)
 
 	// Count cache.
-	heapAllocator.cachedStructTypes.Range(func(key, value interface{}) bool {
+	defaultAllocator.cachedStructTypes.Range(func(key, value interface{}) bool {
 		oldCnt++
 		return true
 	})
@@ -43,7 +43,7 @@ func TestMarkAsScalar(t *testing.T) {
 	MarkAsScalar(reflect.TypeOf(new(int))) // Should be ignored.
 
 	// Count cache against.
-	heapAllocator.cachedStructTypes.Range(func(key, value interface{}) bool {
+	defaultAllocator.cachedStructTypes.Range(func(key, value interface{}) bool {
 		newCnt++
 		return true
 	})

--- a/structtype_test.go
+++ b/structtype_test.go
@@ -32,7 +32,7 @@ func TestMarkAsScalar(t *testing.T) {
 	a.Use(&oldCnt, &newCnt)
 
 	// Count cache.
-	cachedStructTypes.Range(func(key, value interface{}) bool {
+	heapAllocator.cachedStructTypes.Range(func(key, value interface{}) bool {
 		oldCnt++
 		return true
 	})
@@ -43,7 +43,7 @@ func TestMarkAsScalar(t *testing.T) {
 	MarkAsScalar(reflect.TypeOf(new(int))) // Should be ignored.
 
 	// Count cache against.
-	cachedStructTypes.Range(func(key, value interface{}) bool {
+	heapAllocator.cachedStructTypes.Range(func(key, value interface{}) bool {
 		newCnt++
 		return true
 	})

--- a/wrapper.go
+++ b/wrapper.go
@@ -69,7 +69,7 @@ func Wrap(v interface{}) interface{} {
 	}
 
 	wrapperType := cache.(reflect.Type)
-	pw := heapAllocator.New(wrapperType)
+	pw := defaultAllocator.New(wrapperType)
 
 	wrapperPtr := unsafe.Pointer(pw.Pointer())
 	wrapper := pw.Elem()


### PR DESCRIPTION
Per discussion in #13, refactory the `Allocator` design and make it as a store to hold all customization data, including custom functions, scalar kind checks, scalar type checks and opaque pointers. This design enables us to create separated customized clone functions.